### PR TITLE
feat: add LoadingPage on all pages

### DIFF
--- a/src/app/catalog/loading.tsx
+++ b/src/app/catalog/loading.tsx
@@ -1,0 +1,7 @@
+import LoadingPage from "@/components/ui/loading";
+
+const Loading = () => {
+  return <LoadingPage />;
+};
+
+export default Loading;

--- a/src/app/category/[slug]/loading.tsx
+++ b/src/app/category/[slug]/loading.tsx
@@ -1,0 +1,7 @@
+import LoadingPage from "@/components/ui/loading";
+
+const Loading = () => {
+  return <LoadingPage />;
+};
+
+export default Loading;

--- a/src/app/deals/loading.tsx
+++ b/src/app/deals/loading.tsx
@@ -1,0 +1,7 @@
+import LoadingPage from "@/components/ui/loading";
+
+const Loading = () => {
+  return <LoadingPage />;
+};
+
+export default Loading;

--- a/src/app/orders/loading.tsx
+++ b/src/app/orders/loading.tsx
@@ -1,0 +1,7 @@
+import LoadingPage from "@/components/ui/loading";
+
+const Loading = () => {
+  return <LoadingPage />;
+};
+
+export default Loading;

--- a/src/app/product/[slug]/loading.tsx
+++ b/src/app/product/[slug]/loading.tsx
@@ -1,0 +1,7 @@
+import LoadingPage from "@/components/ui/loading";
+
+const Loading = () => {
+  return <LoadingPage />;
+};
+
+export default Loading;

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
           </Button>
         </SheetTrigger>
 
-        <SheetContent side="left">
+        <SheetContent side="left" className="w-[21.875rem]">
           <SheetHeader className="text-left text-lg font-semibold">
             Menu
           </SheetHeader>

--- a/src/components/ui/loading.tsx
+++ b/src/components/ui/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const LoadingPage = () => {
+  return (
+    <div className="flex w-full flex-1 flex-col items-center p-[50%] px-20">
+      <div className="mt-12 w-[100%] animate-pulse flex-row items-center justify-center space-x-1 rounded-xl border p-6">
+        <Skeleton className="h-6 w-[100%] rounded-md bg-gray-300" />
+      </div>
+    </div>
+  );
+};
+
+export default LoadingPage;

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
Foi criado o componente LoadingPage em **components/ui** com a seguinte estrutura:

<img width="894" alt="Screenshot 2023-10-24 at 00 37 35" src="https://github.com/felipemotarocha/fullstackweek-store/assets/60014282/cfcd2e85-e40d-4dda-988c-54d76d4e106f">

Posteriormente, adicionei a chamada do componente criado nas páginas: **catalog**, **category**, **deals**, **orders** e **products**.




