### PR TITLE
fix: ensure orders is shown only for authenticated user

### DIFF
--- a/src/@types/next-auth.d.ts
+++ b/src/@types/next-auth.d.ts
@@ -1,0 +1,13 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  /**
+   * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
+   */
+  interface Session {
+    user: {
+      /** The user's postal address. */
+      id: string;
+    } & DefaultSession["user"];
+  }
+}

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -8,15 +8,15 @@ import OrderItem from "./components/order-item";
 export const dynamic = "force-dynamic";
 
 async function OrderPage() {
-  const user = getServerSession(authOptions);
+  const session = await getServerSession(authOptions);
 
-  if (!user) {
+  if (!session || !session.user) {
     return <p>Access Denied</p>;
   }
 
   const orders = await prismaClient.order.findMany({
     where: {
-      userId: (user as any).id,
+      userId: session.user.id,
     },
     include: {
       orderProducts: {

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -11,7 +11,12 @@ async function OrderPage() {
   const session = await getServerSession(authOptions);
 
   if (!session || !session.user) {
-    return <p>Access Denied</p>;
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-5">
+        <h2 className="font-bold">Acesso Negado!</h2>
+        <p className="text-sm opacity-60">Faça login para ver seus pedidos</p>
+      </div>
+    );
   }
 
   const orders = await prismaClient.order.findMany({


### PR DESCRIPTION
A pagina de Orders está listando TODOS os pedidos criados, independente do usuário autenticado, e mesmo que não exista nenhum usuário autenticado.

**Correção:**
No arquivo src/app/orders/page.tsx
Trocar de:

```typescript
const user = getServerSession(authOptions);
```

Para:
```typescript
const session = await getServerSession(authOptions);
```

A alteração acima foi feita porque o método getServerSession retorna uma Promisse de uma Session. Como o objeto User existe apenas dentro da Session, podemos posteriormente pegar o user através de session.user.

Outras alterações:
Alterado a condicional para validar se existe uma sessão ou um user.
De:
```typescript
if (!user) {
    return <p>Access Denied</p>;
  }
```

Para:
```typescript
if (!session || !session.user) {
    return <p>Access Denied</p>;
  }
```

Aterado a query do prisma para utilizar o valor correto e retirado o "as any".
De:
```typescript
where: {
      userId: (user as any).id,
    }
```

Para:
```typescript
where: {
      userId: session.user.id,
    },
```

Por fim, para evitar erros de typescript referente a propriedade id do objeto User foi criado uma tipagem extendendo a tipagem original do NextAuth ([conforme doc oficial](https://next-auth.js.org/getting-started/typescript#extend-default-interface-properties))

Arquivo src/@types/next-auth.d.ts

```typescript
import { DefaultSession } from "next-auth";

declare module "next-auth" {
  /**
   * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
   */
  interface Session {
    user: {
      /** The user's postal address. */
      id: string;
    } & DefaultSession["user"];
  }
}
```

Com as alterações acima propostas o resultado da página Orders sem usuário logado é o abaixo, conforme esperado.
![image](https://github.com/felipemotarocha/fullstackweek-store/assets/59235732/ae3a9417-f0a5-4865-8d06-12bdc554bba4)

fix #8 