### PR TITLE
fix: ensure persistence don’t be empty after refresh page and remove products from LocalStorage when user remove any product from cart

### DIFF
--- a/src/providers/cart.tsx
+++ b/src/providers/cart.tsx
@@ -36,16 +36,27 @@ export const CartContext = createContext<ICartContext>({
 });
 
 const CartProvider = ({ children }: { children: ReactNode }) => {
-  const [products, setProducts] = useState<CartProduct[]>([]);
+  const LOCAL_STORAGE_KEY = "@fsw-store/cart-products";
+
+  const [products, setProducts] = useState<CartProduct[]>(() => {
+    if (typeof window !== "undefined") {
+      const recoveryProducts = localStorage.getItem(
+        LOCAL_STORAGE_KEY,
+      ) as string;
+      return JSON.parse(recoveryProducts) ?? [];
+    } else {
+      return [];
+    }
+  });
 
   useEffect(() => {
-    setProducts(
-      JSON.parse(localStorage.getItem("@fsw-store/cart-products") || "[]"),
-    );
-  }, []);
-
-  useEffect(() => {
-    localStorage.setItem("@fsw-store/cart-products", JSON.stringify(products));
+    if (typeof window !== "undefined") {
+      if (products.length === 0) {
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
+      } else {
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(products));
+      }
+    }
   }, [products]);
 
   // Total sem descontos


### PR DESCRIPTION
**Description:**
After we did the persistent cart we got an error on the build process. It was previous fixed but after this the build process was successful but the persistent cart stopped working.
Every time after the user refreshes the page all objects inside the LocalStorage become empty.

**Context:**
These changes will ensure that the persistence cart will work on build process and on production and product will be deleted from LocalStorage when user removes it from cart.

**Changes:**
1: Create a **LOCAL_STORAGE_KEY** to make it easy to change or maintain in the future.
2: Pass the **LocalStorage as String** to ensure that it is the behavior.
3: Verify **typeof window !== "undefined"** if so, **".getItem()"** to or **".setItem()"** from LocalStorage.
4: Verify if **"products.length"** equal **0** if so, thats mean user removed some products from the cart and need to remove it from LocalStorage also.

Cheers! 🍺